### PR TITLE
Support modals which are not imported with flag eager:true

### DIFF
--- a/src/use-modal.tsx
+++ b/src/use-modal.tsx
@@ -48,7 +48,7 @@ export function useModal(resolverCallback: CallableFunction | null = null) {
     resetHeaders();
   };
 
-  const resolveComponent = () => {
+  const resolveComponent = async () => {
     if (typeof resolver !== 'function') {
       throw Error("Resolver function not defined. You have to define it at Inertia's entrypoint.");
     }
@@ -56,7 +56,7 @@ export function useModal(resolverCallback: CallableFunction | null = null) {
       return close();
     }
 
-    const component = modal?.component ? resolver(modal.component) : null;
+    const component = modal?.component ? await resolver(modal.component) : null;
 
     setNonce(modal?.nonce);
     if (component) {


### PR DESCRIPTION
In case of using import.meta.glob without flag `{eager: true}`, it is not working. 

```js
globalThis.resolveMomentumModal = async (name) => {
    const modals = import.meta.glob('./Pages/**/*.jsx');
    return await modals[`./Pages/${name}/index.jsx`]();
}
```

Errors: 

![image](https://github.com/josemariagomez/momentum-modal-react/assets/165263923/04210ef1-bcc3-4ef6-87a7-e87b01a1f7b8)


I fixed the issue on this PR. 
Please check it. 

Thanks. 