### PR TITLE
Adds support for resolving modals without eager loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ const resolver = (name) => {
   return modals[`../path/to/your/modals/${name}.jsx`];
 };
 
+// or without eager loading;
+// this returns a Promise wrapped in a function which then gets called in the modal hook
+const resolver = (name) => {
+    const modals = import.meta.glob('../path/to/your/modals/**/*.jsx');
+    return modals[`../path/to/your/modals/${name}.jsx`];
+}
+
 export function YourLayout({children}) {
   return (
     <>


### PR DESCRIPTION
I know that there already is a pull request regarding that issue (https://github.com/josemariagomez/momentum-modal-react/pull/1) but in said PR the `resolveComponent` call isn't treated as an asynchronous call in the `useEffect` call where the event listeners are being reigstered. Therefore the `resolveComponent` would be called at the same time when the event listeners are being registered. I don't know if that would really matter in this case but it's better to handle that in the code I think.

This PR relates to #3